### PR TITLE
Make the event streams into the internal collection to correctly end them

### DIFF
--- a/src/react-bacon.js
+++ b/src/react-bacon.js
@@ -38,7 +38,7 @@ module.exports.BaconMixin = ((function(){
       var buses = bacon['buses.events'] = bacon['buses.events'] || {};
       var bus = buses[eventName];
       if (!bus) {
-        bus = buses[eventName] = buses[eventName] || new Bacon.Bus();
+        bus = buses[eventName] = new Bacon.Bus();
         this[eventName] = function sendEventToStream(event) {
           bus.push(event);
         };


### PR DESCRIPTION
I think this was a bug before, the code was missing to set the stream in the internal collection so that it ends when the componen is unmounted.
