### PR TITLE
Add 'with' function to attach custom props to the event

### DIFF
--- a/src/react-bacon.js
+++ b/src/react-bacon.js
@@ -39,8 +39,18 @@ module.exports.BaconMixin = ((function(){
       var bus = buses[eventName];
       if (!bus) {
         bus = buses[eventName] = new Bacon.Bus();
-        this[eventName] = function sendEventToStream(event) {
+        var handler = this[eventName] = function sendEventToStream(event) {
           bus.push(event);
+        };
+
+        handler.with = function(customEventProps) {
+          return function sendEventWithCustomPropsToStream(event) {
+            for (var prop in customEventProps) {
+              event[prop] = customEventProps[prop];
+            }
+
+            return handler(event);
+          };
         };
       }
       return bus;


### PR DESCRIPTION
This PR adds a 'with' function to the handler fn so that you can set custom properties in the event before dispatching it into the `Bacon.Bus`. A typical use case for this is when you have a component that is simple enough to have the children rendered inline, and we have a handler in each particular child:

``` js
/** @jsx React.DOM */
...
componentWillMount: function() {
  this.eventStream('itemClicks').
    doAction('.preventDefault').
    map('.itemId'). // I have access to the item id that was clicked
    ...
},
render: function() {
  var items = this.props.items.map(this.renderItem);
  return <ul>{items}</ul>
},

renderItem: function(item) {
  return <li><a onClick={ this.itemClicks.with({ itemId: item.id }) }></a></li>
}
```

I think this is a handy feature, and I've already needed something like this when using this lib, which is awesome by the way.
