### PR TITLE
Add `onValue()` method for binding event handlers

### DIFF
--- a/dist/react-bacon.js
+++ b/dist/react-bacon.js
@@ -68,6 +68,12 @@ module.exports.BaconMixin = ((function(){
       unsubscribers.push(unsubscribe);
       return unsubscribe;
     },
+    onValue: function (observable) {
+      var bacon = this._bacon = this._bacon || {};
+      var unsubscribers = bacon.unsubscribers = bacon.unsubscribers || [];
+      var args = Array.prototype.slice.call(arguments, 1);
+      unsubscribers.push(observable.onValue.apply(observable, args));
+    },
     componentDidUpdate: function() {
       var bacon = this._bacon;
       if (bacon) {

--- a/spec/react-bacon_spec.js
+++ b/spec/react-bacon_spec.js
@@ -83,20 +83,25 @@ describe('BaconMixin', function() {
           stream.onValue(function() {
             // Does something
           });
+          this.onValue(this.props.bus, this.handleEvent);
         },
+        handleEvent: function () {},
         render: function() {
           return <div onClick={this.clicks}/>
         }
       });
 
-      var component = Utils.renderIntoDocument(<Component />);
+      var bus = new Bacon.Bus();
+      var component = Utils.renderIntoDocument(<Component bus={bus} />);
 
       expect(stream.hasSubscribers()).toBe(true);
+      expect(bus.hasSubscribers()).toBe(true);
 
       var unmounted = React.unmountComponentAtNode(component.getDOMNode().parentNode);
       expect(unmounted).toBe(true);
 
       expect(stream.hasSubscribers()).toBe(false);
+      expect(bus.hasSubscribers()).toBe(false);
     });
   });
 });

--- a/src/react-bacon.js
+++ b/src/react-bacon.js
@@ -67,6 +67,12 @@ module.exports.BaconMixin = ((function(){
       unsubscribers.push(unsubscribe);
       return unsubscribe;
     },
+    onValue: function (observable) {
+      var bacon = this._bacon = this._bacon || {};
+      var unsubscribers = bacon.unsubscribers = bacon.unsubscribers || [];
+      var args = Array.prototype.slice.call(arguments, 1);
+      unsubscribers.push(observable.onValue.apply(observable, args));
+    },
     componentDidUpdate: function() {
       var bacon = this._bacon;
       if (bacon) {


### PR DESCRIPTION
In our use of React and Bacon it's been a common use case to add handlers to some external stream (e.g. a `Bacon.Bus` passed to the component in props). These handlers must be unsubscribed when the component unmounts, which would typically result in tedious code like this:

``` js
componentWillMount: function () {
  this._fooUnsubscribe = this.props.bus.filter(/*...*/).onValue(this.foo);
  this._barUnsubscribe = this.props.bus.map(/*...*/).onValue(this.bar);
  this._bazUnsubscribe = stream.onValue(this.baz);
},
componentWillUnmount: function () {
  this._fooUnsubscribe();
  this._barUnsubscribe();
  this._bazUnsubscribe();
}
```

This pull request adds method `onValue()` to `BaconMixin` that can be used to add handlers that will automatically be unsubscribed when the component unmounts, allowing the previous example to be rewritten as:

``` js
componentWillMount: function () {
  this.onValue(this.props.bus.filter(/*...*/), this.foo);
  this.onValue(this.props.bus.map(/*...*/), this.bar);
  this.onValue(stream, this.baz);
}
```
