### PR TITLE
Fix for failing component unmount test

### DIFF
--- a/spec/react-bacon_spec.js
+++ b/spec/react-bacon_spec.js
@@ -91,12 +91,12 @@ describe('BaconMixin', function() {
 
       var component = Utils.renderIntoDocument(<Component />);
 
-      expect(stream.hasSubscribers()).toBe(true);
+      expect(stream.dispatcher.hasSubscribers()).toBe(true);
 
       var unmounted = React.unmountComponentAtNode(component.getDOMNode().parentNode);
       expect(unmounted).toBe(true);
 
-      expect(stream.hasSubscribers()).toBe(false);
+      expect(stream.dispatcher.hasSubscribers()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Test failure detected while running jasmine specs with latest Bacon.js (0.7.30)

Testing jasmine specs via PhantomJS
 BaconMixin
   #eventStream
     - returns the stream for that defined name......√
     - returns always the same event stream......√
     - defines a function property with the name of the stream......√
     - that defined function can be used as event handler, and pushes to the stream......√
     - removes subscribers when the component unmounts......×
       TypeError: 'undefined' is not a function (evaluating 'stream.hasSubscribers()') in /project/node_modules/react-bacon/tmp/specs.js (line 22246) (1)
